### PR TITLE
feat(mautrix-whatsapp): change service to publish not ready addresses

### DIFF
--- a/charts/mautrix-whatsapp/templates/service.yaml
+++ b/charts/mautrix-whatsapp/templates/service.yaml
@@ -14,3 +14,5 @@ spec:
       name: http
   selector:
     {{- include "mautrix-whatsapp.selectorLabels" . | nindent 4 }}
+  publishNotReadyAddresses: true
+


### PR DESCRIPTION
Add `publishNotReadyAddresses: true` to `service` template

source: https://docs.mau.fi/bridges/general/docker-setup.html?bridge=whatsapp#kubernetes